### PR TITLE
fix error check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,6 +166,12 @@ func checkFiles(ctx context.Context, access string) (keys []string, n int, err e
 			keys = append(keys, fullKey)
 			n++
 		}
+		if objects.Err() != nil {
+			return keys, 0, errs.Wrap(objects.Err())
+		}
+	}
+	if buckets.Err() != nil {
+		return keys, 0, errs.Wrap(buckets.Err())
 	}
 
 	return keys, n, nil


### PR DESCRIPTION
As I learned, when access grant is bad, buckets.Next() is false, so we need to check
the err after the loop.