### PR TITLE
cmd,demo: Update help text and command output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,4 @@
-GOOS=darwin GOARCH=arm64 go build -o bin/accesschecker-arm64-darwin main.go
-GOOS=freebsd GOARCH=amd64 go build -o bin/accesschecker-amd64-freebsd main.go
-GOOS=linux GOARCH=arm go build -o bin/accesschecker-arm-linux main.go
-GOOS=linux GOARCH=arm64 go build -o bin/accesschecker-arm64-linux main.go
-
-# from https://freshman.tech/snippets/go/cross-compile-go-programs/
+# based partially on https://freshman.tech/snippets/go/cross-compile-go-programs/
 # Windows
 # 64-bit
 GOOS=windows GOARCH=amd64 go build -o bin/accesschecker-amd64.exe main.go
@@ -12,13 +7,19 @@ GOOS=windows GOARCH=386 go build -o bin/accesschecker-386.exe main.go
 
 # Mac
 # 64-bit
-GOOS=darwin GOARCH=amd64 go build -o bin/accesschecker-amd64-darwin main.go
+GOOS=darwin GOARCH=amd64 go build -o bin/accesschecker-darwin-amd64 main.go
+GOOS=darwin GOARCH=arm64 go build -o bin/accesschecker-darwin-arm64 main.go
 # 32-bit
 # has error: "go: unsupported GOOS/GOARCH pair darwin/386"
 # GOOS=darwin GOARCH=386 go build -o bin/accesschecker-386-darwin main.go
 
 # Linux
 # 64-bit
-GOOS=linux GOARCH=amd64 go build -o bin/accesschecker-amd64-linux main.go
+GOOS=linux GOARCH=amd64 go build -o bin/accesschecker-linux-amd64 main.go
+GOOS=linux GOARCH=arm64 go build -o bin/accesschecker-linux-arm64 main.go
 # 32-bit
-GOOS=linux GOARCH=386 go build -o bin/accesschecker-386-linux main.go
+GOOS=linux GOARCH=386 go build -o bin/accesschecker-linux-386 main.go
+GOOS=linux GOARCH=arm go build -o bin/accesschecker-linux-arm main.go
+
+# Free BSD
+GOOS=freebsd GOARCH=amd64 go build -o bin/accesschecker-freebsd-amd64 main.go

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,10 +31,10 @@ var outputtingGrant bool
 var rootCmd = &cobra.Command{
 	Use:   "accesschecker [accessgrant]",
 	Short: "Check for files uploaded with an empty passphrase in a project",
-	Long: `This command is used to determine if you have previously uploaded unencrypted files to a Storj DCS project.
-			To use, go to the Satellite UI, and generate a new access grant for the project you are interested in.
-			Then, run the command with the access you copied from the Satellite UI. It will tell you if you have any unencrypted files uploaded, and what they are called.
-			If you need an (unsafe) "no passphrase" access so that you can download and remove your unencrypted files using uplink, run with the flag "--output-empty-passphrase-access".`,
+	Long: `This command is used to determine if you have previously uploaded files with an empty encryption passphrase to a Storj DCS project.
+To use, go to the Satellite UI, and generate a new access grant for the project you are interested in.
+Then, run the command with the access you copied from the Satellite UI. It will tell you if you have any files uploaded with an empty encryption passphrase, and list the filepaths.
+If you need an (unsafe) "no passphrase" access so that you can download and remove your unencrypted files using uplink, run with the flag "--output-empty-passphrase-access".`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			cmd.Println("You are missing an argument.\n")
@@ -113,22 +113,22 @@ func beginCheck(cmd *cobra.Command, accessArg string) error {
 	}
 	keys, n, err := checkFiles(ctx, accessGrant)
 	if err != nil {
-		return errs.New("Error checking for unencrypted files: %+v", err)
+		return errs.New("Error checking for files uploaded with empty passphrase: %+v", err)
 	}
 	if n > 0 {
-		cmd.Printf("\nYou have %d files uploaded without encryption in this project:\n\n", n)
+		cmd.Printf("\nYou have %d files uploaded with an empty encryption passphrase in this project:\n\n", n)
 		for _, k := range keys {
 			cmd.Println(k)
 		}
 
 		if outputtingGrant {
 			cmd.Println("\n==================================================\n")
-			cmd.Printf("Generated empty passphrase grant:\n\n%s\n\n", accessGrant)
-			cmd.Println("WARNING: This access is capable of uploading and downloading unencrypted files to and from your project. We recommend using it only to download and subsequently remove files which are unencrypted.")
+			cmd.Printf("Generated access grant with empty passphrase:\n\n%s\n\n", accessGrant)
+			cmd.Println("WARNING: This access is capable of uploading and downloading files with an empty passphrase to and from your project. We recommend using it only to download and subsequently remove files which are unencrypted.")
 		}
 		return nil
 	}
-	cmd.Println("You do not have any files uploaded without encryption in this project.")
+	cmd.Println("You do not have any files uploaded with an empty encryption passphrase in this project.")
 	return nil
 }
 

--- a/demo.md
+++ b/demo.md
@@ -3,8 +3,11 @@
 ## Help text
 
 ```
-$ accesschecker
-You are missing an argument.
+ accesschecker --help
+This command is used to determine if you have previously uploaded files with an empty encryption passphrase to a Storj DCS project.
+To use, go to the Satellite UI, and generate a new access grant for the project you are interested in.
+Then, run the command with the access you copied from the Satellite UI. It will tell you if you have any files uploaded with an empty encryption passphrase, and list the filepaths.
+If you need an (unsafe) "no passphrase" access so that you can download and remove your unencrypted files using uplink, run with the flag "--output-empty-passphrase-access".
 
 Usage:
   accesschecker [accessgrant] [flags]
@@ -21,7 +24,7 @@ The access you provide can be a new unrestricted access grant created from the S
 ```
 $ accesschecker 1QiUipyf19MS5ZMC2y7knDt4jRtf53SgpuXnoX8mdfEqQkx2bUbXTdYhoAxZyioxaWhmjSJR2XHFcBuWJv85oPKSeJ7ZY6XQcUJdRQYrxiG1s6Gf2i6Xxrp1YyAbdG7kythpA6jxr5JBWnMffdioEha9DJWSeHrLUbLcAMTYRjZH1c2yXbg2uxNcAypjbs5dh4Gb4Ksyv4WN7jqQrRqx3eXqf873Z1zFCi8EaczhH4LhEenLgfmUbkL4NAkCRZ8EM5Zp89oP
 
-You have 2 files uploaded without encryption in this project:
+You have 2 files uploaded with an empty encryption passphrase in this project:
 
 sj://asdf/DEVELOPING.md
 sj://moby/README.md
@@ -32,18 +35,18 @@ sj://moby/README.md
 ```
 $ accesschecker 1QiUipyf19MS5ZMC2y7knDt4jRtf53SgpuXnoX8mdfEqQkx2bUbXTdYhoAxZyioxaWhmjSJR2XHFcBuWJv85oPKSeJ7ZY6XQcUJdRQYrxiG1s6Gf2i6Xxrp1YyAbdG7kythpA6jxr5JBWnMffdioEha9DJWSeHrLUbLcAMTYRjZH1c2yXbg2uxNcAypjbs5dh4Gb4Ksyv4WN7jqQrRqx3eXqf873Z1zFCi8EaczhH4LhEenLgfmUbkL4NAkCRZ8EM5Zp89oP --output-empty-passphrase-access
 
-You have 2 files uploaded without encryption in this project:
+You have 2 files uploaded with an empty encryption passphrase in this project:
 
 sj://asdf/DEVELOPING.md
 sj://moby/README.md
 
 ==================================================
 
-Generated empty passphrase grant:
+Generated access grant with empty passphrase:
 
 1QiUipyf19MS5ZMC2y7knDt4jRtf53SgpuXnoX8mdfEqQkx2bUbXTdYhoAxZyioxaWhmjSJR2XHFcBuWJv85oPKSeJ7ZY6XQcUJdRQYrxiG1s6Gf2i6Xxrp1YyAbdG7kythpA6jxr5JBWnMffdioEha9DJWSeHrLUbLcAMTYRjZH1c2yXbg2uxNcAypjbs5dh4Gb4Ksyv4WN7jqQrRqx3eXqf873Z1zFCi8EaczhH4LhEenLgfmUbkL4NAkCRZ8EM5Zp89oP
 
-WARNING: This access is capable of uploading and downloading unencrypted files to and from your project. We recommend using it only to download and subsequently remove files which are unencrypted.
+WARNING: This access is capable of uploading and downloading files with an empty passphrase to and from your project. We recommend using it only to download and subsequently remove files which are unencrypted.
 
 ```
 
@@ -102,5 +105,5 @@ upload DEVELOPING.md to sj://asdf/DEVELOPING.md
 
 ```
 $ accesschecker 1QiUipyf19MS5ZMC2y7knDt4jRtf53SgpuXnoX8mdfEqQkx2bUbXTdYhoAxZyioxaWhmjSJR2XHFcBuWJv85oPKSeJ7ZY6XQcUJdRQYrxiG1s6Gf2i6Xxrp1YyAbdG7kythpA6jxr5JBWnMffdioEha9DJWSeHrLUbLcAMTYRjZH1c2yXbg2uxNcAypjbs5dh4Gb4Ksyv4WN7jqQrRqx3eXqf873Z1zFCi8EaczhH4LhEenLgfmUbkL4NAkCRZ8EM5Zp89oP --output-empty-passphrase-access
-You do not have any files uploaded without encryption in this project.
+You do not have any files uploaded with an empty encryption passphrase in this project.
 ```


### PR DESCRIPTION
Don't describe files as "unencrypted". Rather, describe them as
"uploaded with an empty encryption passphrase", because technically
these files are still encrypted.